### PR TITLE
Changed API XML encoding to UTF-8

### DIFF
--- a/app/src/main/java/com/spelder/tagyourit/networking/TagXmlParser.java
+++ b/app/src/main/java/com/spelder/tagyourit/networking/TagXmlParser.java
@@ -26,7 +26,7 @@ class TagXmlParser {
     try {
       XmlPullParser parser = Xml.newPullParser();
       parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false);
-      parser.setInput(in, null);
+      parser.setInput(in, "utf-8");
       parser.nextTag();
       return readFeed(parser);
     } finally {


### PR DESCRIPTION
The tag entitled [Ungdomsdröm](https://www.barbershoptags.com/tag-4703-Ungdomsdr%C3%B6m) is not being rendered correctly in the list or titles.  It seems that the root of this problem is coming from the fact that the XML returned by the barbershoptags.com API is not specifying its encoding.  It seems to be using UTF-8, but the XML parser is interpreting it as ISO 8859-1.  Here I have forced the parser to use UTF-8 encoding, which fixes the o-umlaut encoding.